### PR TITLE
Merge Dev Branch

### DIFF
--- a/src/main/java/nl/Steffion/BlockHunt/BlockHunt.java
+++ b/src/main/java/nl/Steffion/BlockHunt/BlockHunt.java
@@ -110,6 +110,7 @@ public class BlockHunt extends JavaPlugin implements Listener {
 		getServer().getPluginManager().registerEvents(new OnFoodLevelChangeEvent(), this);
 		getServer().getPluginManager().registerEvents(new OnInventoryClickEvent(), this);
 		getServer().getPluginManager().registerEvents(new OnInventoryCloseEvent(), this);
+		getServer().getPluginManager().registerEvents(new OnPlayerSwapHandItemsEvent(), this);
 
 		// Removed - This is handled by WorldGuard now.
 		// getServer().getPluginManager().registerEvents(

--- a/src/main/java/nl/Steffion/BlockHunt/Listeners/OnInventoryClickEvent.java
+++ b/src/main/java/nl/Steffion/BlockHunt/Listeners/OnInventoryClickEvent.java
@@ -25,10 +25,8 @@ public class OnInventoryClickEvent implements Listener {
 		Player player = (Player) event.getWhoClicked();
 
 		for (Arena arena : MemoryStorage.arenaList) {
-			if (arena.playersInArena.contains(player) && !arena.seekers.contains(player)) {
-				if (event.getSlot() == 8 || event.getSlot() == 39) {
-					event.setCancelled(true);
-				}
+			if (arena.playersInArena.contains(player)) {
+				event.setCancelled(true);
 			}
 		}
 

--- a/src/main/java/nl/Steffion/BlockHunt/Listeners/OnPlayerQuitEvent.java
+++ b/src/main/java/nl/Steffion/BlockHunt/Listeners/OnPlayerQuitEvent.java
@@ -24,9 +24,9 @@ public class OnPlayerQuitEvent implements Listener {
 		}
 	}
 
-	@EventHandler(priority = EventPriority.HIGHEST)
-	public void onPlayerJoinEvent(PlayerJoinEvent event) {
-		Player playerJoining = event.getPlayer();
-		playerJoining.teleport(playerJoining.getWorld().getSpawnLocation());
-	}
+//	@EventHandler(priority = EventPriority.HIGHEST)
+//	public void onPlayerJoinEvent(PlayerJoinEvent event) {
+//		Player playerJoining = event.getPlayer();
+//		playerJoining.teleport(playerJoining.getWorld().getSpawnLocation());
+//	}
 }

--- a/src/main/java/nl/Steffion/BlockHunt/Listeners/OnPlayerSwapHandItemsEvent.java
+++ b/src/main/java/nl/Steffion/BlockHunt/Listeners/OnPlayerSwapHandItemsEvent.java
@@ -1,0 +1,25 @@
+package nl.Steffion.BlockHunt.Listeners;
+
+import nl.Steffion.BlockHunt.Arena;
+import nl.Steffion.BlockHunt.ArenaHandler;
+import nl.Steffion.BlockHunt.MemoryStorage;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+
+public class OnPlayerSwapHandItemsEvent implements Listener {
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onPlayerSwapHandItemsEvent(PlayerSwapHandItemsEvent event) {
+        // Early exit if no one is in any arena
+        if (ArenaHandler.noPlayersInArenas()) return;
+
+        Player player = event.getPlayer();
+        for (Arena arena : MemoryStorage.arenaList) {
+            if (arena.playersInArena.contains(player)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- What was originally just a quick hack to see if shifting the end game stuff onto the next tick would stop a bunch of odd things happening in certain situations actually seems to work well. May as well just leave it.

    example: killing the last seeker with an arrow caused countless issues with "Removing entity while ticking" errors and from there things went south fast. 

- Prevents a whole bunch of other glitches/exploits by just refusing to allow inventory modifications by a player during a blockhunt match. 

    example: crafting their hay block disguise into wheat, then disguising as that which then turns them into wheat seeds, and from there on out they are invisible as long as they keep moving.

- Stop teleporting all players to the spawn of that world when connecting to the server. It's outside the scope of this plugin, and kind of annoying. :P